### PR TITLE
RU-GETECH: Wrong exploit on Testing for Fragment Injection (#1920)

### DIFF
--- a/Document/0x05h-Testing-Platform-Interaction.md
+++ b/Document/0x05h-Testing-Platform-Interaction.md
@@ -520,7 +520,7 @@ Intent i = new Intent();
 i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
 i.setClassName("pt.claudio.insecurefragment","pt.claudio.insecurefragment.MainActivity");
 i.putExtra(":android:show_fragment","pt.claudio.insecurefragment.MyFragment");
-Intent intent = i.setData(Uri.parse("https://security.claudio.pt"));
+i.setData(Uri.parse("https://security.claudio.pt"));
 startActivity(i);
 ```
 


### PR DESCRIPTION
In the exploit.apk, the code is, i.setData(Uri.parse("https://security.claudio.pt")); not Intent intent = xxx

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [ ] Your contribution is written in the 2nd person (e.g. you)
- [ ] Your contribution is written in an active present form for as much as possible.
- [ ] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [ ] Your contribution has proper formatted markdown and/or code
- [ ] Any references to website have been formatted as [TEXT](URL “NAME”)
- [ ] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR closes #< insert number here >.
